### PR TITLE
Configurando posts em ordem decrescente de data de publicação

### DIFF
--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -9,6 +9,7 @@ const postQuery = `{
           slug
         }
         frontmatter {
+          date_timestamp: date
           date(locale: "pt-br", formatString: "DD MMM[,] YYYY")
           description
           title
@@ -24,6 +25,9 @@ const postQuery = `{
 const flatten = arr => {
   return arr.map(({ node: { frontmatter, ...rest } }) => ({
     ...frontmatter,
+    date_timestamp: parseInt(
+      (new Date(frontmatter.date_timestamp).getTime() / 1000).toFixed(0)
+    ),
     ...rest,
   }))
 }


### PR DESCRIPTION
Criei esse PR para que a busca feita em seu blog retorne os posts mais atuais nas primeiras posições. 
Após aceitar o PR você deverá refazer o indíce do blog no algolia e realizar a seguinte configuração:

1. Acesse seu indice de produção depois Configuration e em seguida Ranking and Sorting
2. Clique em "Add sort-by attribute" e aponte para o campo date_timestamp
3. Informe "Descending" na linha que foi criada dessa configuração.
