### PR TITLE
Resolvendo url do post no feed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,4 @@
+const path = require(`path`)
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
 })
@@ -8,11 +9,12 @@ const feeds = [
   {
     serialize: ({ query: { site, allMarkdownRemark } }) => {
       return allMarkdownRemark.edges.map(edge => {
+        const postUrl = path.join(site.siteMetadata.siteUrl, edge.node.fields.slug)
         return Object.assign({}, edge.node.frontmatter, {
           description: edge.node.frontmatter.description,
           date: edge.node.frontmatter.date,
-          url: site.siteMetadata.siteUrl + edge.node.fields.slug,
-          guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
+          url: postUrl,
+          guid: postUrl,
           custom_elements: [{ 'content:encoded': edge.node.html }]
         })
       })


### PR DESCRIPTION
## Descrição

No arquivo de [feed rss](https://www.felipefialho.com/feed.xml) o link para os posts ficaram faltando um`/` e os leitores de feed acabam não referenciando o link pro post de forma correta e, por isso, não dá pra acessar o post a menos que seja editado a url na barra de navegação