### PR TITLE
fix: change link underline animation to 'display/hide entirely' style

### DIFF
--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -109,27 +109,14 @@ export const Text2 = css`
 
 export const LinkTransition = css`
   & {
-    position: relative;
-    will-change: transform;
-  }
-
-  &:after {
-    background-color: var(--highlightColor);
-    content: '';
-    height: 2px;
-    left: 0;
-    margin-top: ${V.Space.xxs};
-    position: absolute;
-    top: 100%;
-    transform: scaleX(0);
-    transition: transform ${V.Transition.default};
-    width: 100%;
+    border-bottom: 2px solid transparent;
+    transition: border-color ${V.Transition.default};
+    padding-bottom: 0.1rem;
+    will-change: border-color;
   }
 
   &:hover {
-    &:after {
-      transform: scaleX(1)
-    }
+    border-color: var(--highlightColor);
   }
 `
 


### PR DESCRIPTION
hey, my old buddy.

i'm learning some stuff about front-end and i was reading your blog 'cause i want to be a good dev, like you, of course.

while i was reading this [post](https://felipefialho.com/blog/design-system-venice-e-as-pecas-do-lego/), i found this glitch:

![there is a double line link, when cursor hovers it, underline appears animated, left to right, only in one line](https://i.ibb.co/1fKr2Ty/before.gif)

this is on chrome. it also happens on firefox, but in another way.

i became curious why this is happening and i started to hack your code. i realized you created a element with after pseudoelement, which seems great to me, but it only works in a single line. i guess this trick, this kind of translate animation, is common in menu links, which it's very rare to divide in two or more lines. but, in a link which corresponds to a post title, it could happen more frequently, it just only needs a large title and/or a narrow screen.

so i decided to purpose a simple solution:

![there is a double line link, when cursor over it, underline is displayed entirely animated](https://i.ibb.co/12m05Cd/after.gif)

i think it's not fancy as well left-to-right animation but it's cool too. if you could, tell me what you thought about it.

cheers and vai corinthians!